### PR TITLE
Refactor: connectSocketRoomsChange 함수 promise 반환하도록 하여 roomlist 화면에서 socket연결 실패 시 후처리 구현.

### DIFF
--- a/chatting-app/pages/chat/list.tsx
+++ b/chatting-app/pages/chat/list.tsx
@@ -34,9 +34,9 @@ import {
 } from "../../apis/roomApis";
 import { CHATO_TOKEN } from "../../constants/etc";
 import {
-  connectSocketRoomsChange,
   disconnectSocketRoomsChange,
   sendRoomDeleteMessage,
+  startRoomsSubscribing,
 } from "../../utils/socket";
 import {
   arrangeEachRoom,
@@ -315,13 +315,18 @@ function ChattingList({ rooms }: { rooms: IRoom[] }) {
     router.push("/user/signin");
   };
   useEffect(() => {
-    listSocketStomp = new SocketStomp();
-    connectSocketRoomsChange(handleAllRoomsStatusChange);
-    if (!getAccessTokenInCookies(CHATO_TOKEN)) {
-      setRoomList(
-        getArrangedRoomList(getPinnedSubjectStorage(), chatRooms, userNo)
+    (async () => {
+      listSocketStomp = new SocketStomp();
+      const isRoomsSubscribingStartedSuccessfully = await startRoomsSubscribing(
+        handleAllRoomsStatusChange
       );
-    }
+      if (!isRoomsSubscribingStartedSuccessfully) router.push("/");
+      if (!getAccessTokenInCookies(CHATO_TOKEN)) {
+        setRoomList(
+          getArrangedRoomList(getPinnedSubjectStorage(), chatRooms, userNo)
+        );
+      }
+    })();
     return () => {
       disconnectSocketRoomsChange();
       renderingCount = 0;

--- a/chatting-app/utils/socket.ts
+++ b/chatting-app/utils/socket.ts
@@ -40,7 +40,7 @@ export const makeUserName = (userNickName: string) => {
   return userNickName ? userNickName : generateRandonUserId();
 };
 
-export const subscribeChatMessage = (
+const subscribeChatMessage = (
   id: number,
   userId: string,
   handleSubscribedChatMessages: SocketCallback
@@ -52,7 +52,7 @@ export const subscribeChatMessage = (
   );
 };
 
-const connectSocketCommunication = () => {
+const connectSocketCommunication = (): Promise<boolean> => {
   return new Promise((connectSuccess, connectFail) => {
     chattingSocketStomp.stomp.connect(
       {},
@@ -66,15 +66,31 @@ const connectSocketCommunication = () => {
   });
 };
 
-export const connectSocketRoomsChange = (
+export const startRoomsSubscribing = async (
   handleAllRoomsStatusChange: SocketCallback
 ) => {
-  listSocketStomp.stomp.connect({}, () => {
+  const isRoomsSubscribingStartedSuccessfully =
+    await connectSocketRoomsChange();
+  if (isRoomsSubscribingStartedSuccessfully)
     subscribeAllRoomsChange(handleAllRoomsStatusChange);
+  return isRoomsSubscribingStartedSuccessfully;
+};
+
+const connectSocketRoomsChange = (): Promise<boolean> => {
+  return new Promise((connectSuccess, connectFail) => {
+    listSocketStomp.stomp.connect(
+      {},
+      () => {
+        connectSuccess(true);
+      },
+      () => {
+        connectFail(false);
+      }
+    );
   });
 };
 
-export const subscribeAllRoomsChange = (
+const subscribeAllRoomsChange = (
   handleAllRoomsStatusChange: SocketCallback
 ) => {
   listSocketStomp.stomp.subscribe(


### PR DESCRIPTION
* what to do next
1. Axios utils 분리.
2. handleToken 외부로 분리해서 apis의 catch에서 호출.
3. Next image 변경 안되는것 문제 해결.
4. 채팅 이미지 클래스로 프레임이 이미지 모두 감싸도록 수정.
5. 요청 경로, 자주 사용되는 클래스 이름들 문자열에서 변수로 변경.